### PR TITLE
Added Kth Largest Element in Stream

### DIFF
--- a/Pseudocode/Heaps/Kth Largest Element in Stream/SourceCode.tex
+++ b/Pseudocode/Heaps/Kth Largest Element in Stream/SourceCode.tex
@@ -22,30 +22,30 @@
 
   \caption{Kth Largest Element in a Stream}
   \begin{algorithmic}[1]
+    \LeftComment $max\_heap$ buffers k elements from the stream.
+    \LeftComment $max\_heap$ is a priority queue : The largest element is at the top
+    \LeftComment $array$ must be at least $k-1$ elements long.
     \Statex
-    \Function{Init\_Queue}{$array$, $k$}
-        \LeftComment $queue$ buffers k elements from the stream.
-        \LeftComment $queue$ is a priority queue: its elements are kept in ascending order.
-        \LeftComment $array$ must be at least $k-1$ elements long.
-        \Statex
-        \State $queue \gets$ Empty queue
-        \For{all elements in $array$}
-            \State $queue.push(element)$
+    \Function{Init\_Heap}{$array$, $k$}
+        \State $max\_heap \gets$ Empty max\_heap
+        \For{\textbf{each} element \textbf{in } $array$}
+            \State $max\_heap.push(element)$
         \EndFor
     \EndFunction
 
     \Statex
-    \Statex
     
     \Function{Add\_New\_Value\_From\_Stream}{$val$}
-        \State $queue.push(val)$
-        \While{$queue.size > k$}
-            \State $queue.pop$
+        \State $max\_heap.push(val)$
+        \While{$max\_heap.size > k$}
+            \State $max\_heap.pop$
         \EndWhile
-        \State \Return{$queue.front$}
+        \State \Return{$max\_heap.top$}
     \EndFunction
   \end{algorithmic}
   
 \end{algorithm}
 
+\noindent
+\textbf{Note} : The goal of the algorithm is to output the $Kth$ largest element as soon as we encounter a new element of the stream.
 \end{document}

--- a/Pseudocode/Queue/Kth Largest Element in Stream/SourceCode.tex
+++ b/Pseudocode/Queue/Kth Largest Element in Stream/SourceCode.tex
@@ -1,0 +1,51 @@
+% Set the Page Layout
+\documentclass[12pt]{article}
+\usepackage[inner = 2.0cm, outer = 2.0cm, top = 2.0cm, bottom = 2.0cm]{geometry}
+
+% Package to write pseudo-codes
+\usepackage{algorithm}
+
+% Remove the 'end' at the end of the algorithm
+\usepackage[noend]{algpseudocode}
+
+% Define Left Justified Comments
+\algnewcommand{\LeftComment}[1]{\Statex \(\triangleright\) #1}
+
+% Remove the Numbering of the Algorithm
+\usepackage{caption}
+\DeclareCaptionLabelFormat{algnonumber}{Algorithm}
+\captionsetup[algorithm]{labelformat = algnonumber}
+
+\begin{document}
+
+\begin{algorithm}
+
+  \caption{Kth Largest Element in a Stream}
+  \begin{algorithmic}[1]
+    \Statex
+    \Function{Init\_Queue}{$array$, $k$}
+        \LeftComment $queue$ buffers k elements from the stream.
+        \LeftComment $queue$ is a priority queue: its elements are kept in ascending order.
+        \LeftComment $array$ must be at least $k-1$ elements long.
+        \Statex
+        \State $queue \gets$ Empty queue
+        \For{all elements in $array$}
+            \State $queue.push(element)$
+        \EndFor
+    \EndFunction
+
+    \Statex
+    \Statex
+    
+    \Function{Add\_New\_Value\_From\_Stream}{$val$}
+        \State $queue.push(val)$
+        \While{$queue.size > k$}
+            \State $queue.pop$
+        \EndWhile
+        \State \Return{$queue.front$}
+    \EndFunction
+  \end{algorithmic}
+  
+\end{algorithm}
+
+\end{document}


### PR DESCRIPTION
This is my version of the Kth Largest Element in a Stream Algorithm.
This PR concerns the issue [\#40](https://github.com/Just-A-Visitor/Algorithmic-Pseudocode/issues/40).

I kept the basic **2-function structure** that was given as a template in LeetCode.

If the priority queue uses a **heap data structure**, time complexity is :
1. O(log(n!)) for the initialization of the queue, n being the number of elements in the given array. Indeed, it requires n O(log(k)) insertions, k increasing from 1 to n as elements are inserted.
2. O(log(k)) for adding a new element from the stream. Indeed, it requires 1 insertion and 1 deletion (except for the first call after init) both of which are O(log(k)).